### PR TITLE
Add meta viewport to fix mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="utf-8">
   <title>selfcare.tech - developer resources for self-care</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Google Fonts -->
   <link href="https://fonts.googleapis.com/css?family=Baloo+Paaji|Roboto:300,300italic,700,700italic" rel="stylesheet">
   <!-- Picnic CSS minified -->


### PR DESCRIPTION
On my Android device using Firefox and Chrome the Website was displaying the page in desktop format, this should address this and properly show a responsive page.