### PR TITLE
Remove unused Roboto font from google font css

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <title>selfcare.tech - developer resources for self-care</title>
   <!-- Google Fonts -->
-  <link href="https://fonts.googleapis.com/css?family=Baloo+Paaji|Roboto:300,300italic,700,700italic" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Baloo+Paaji" rel="stylesheet">
   <!-- Picnic CSS minified -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/picnic@6.5.0/picnic.min.css">
   <link rel="stylesheet" href="css/main.css" media="screen">


### PR DESCRIPTION
Removed Roboto font from google font css, as it doesn't seem to be used from current css.