### PR TITLE
Enable smooth scroll for users which do not prefer reduced motion

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -7,6 +7,12 @@ body {
   color: #fff;
 }
 
+@media screen and (prefers-reduced-motion: no-preference) {
+  body {
+    scroll-behavior: smooth;
+  }
+}
+
 svg {
   max-height: 150px;
   max-width: 90%;


### PR DESCRIPTION
This enables `smooth-scroll` when selecting a category, but only for users who do not "prefer reduces motion", this is only supported in Firefox and Safari, people who use other browsers and therefore cannot opt-out of this will not get the smooth-scroll experience.

Feel free to close this if you do not think this is necessary on selfcare.tech :)